### PR TITLE
feat(blocking): ship full sync wrapper parity

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ keywords = ["kicad", "eda", "pcb", "ipc"]
 categories = ["api-bindings", "asynchronous"]
 include = [
     "/src/**",
+    "/test-scripts/kicad-ipc-cli.rs",
+    "/docs/TEST_CLI.md",
     "/README.md",
     "/LICENSE",
     "/Cargo.toml",
@@ -21,6 +23,11 @@ default = ["async"]
 async = ["dep:nng", "dep:prost", "dep:prost-types", "dep:tokio"]
 blocking = ["async"]
 tracing = ["dep:tracing"]
+
+[[bin]]
+name = "kicad-ipc-cli"
+path = "test-scripts/kicad-ipc-cli.rs"
+required-features = ["blocking"]
 
 [dependencies]
 nng = { version = "1.0.1", optional = true }

--- a/docs/TEST_CLI.md
+++ b/docs/TEST_CLI.md
@@ -6,8 +6,10 @@ CLI binary path:
 Run help:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- help
+cargo run --features blocking --bin kicad-ipc-cli -- help
 ```
+
+The CLI uses `KiCadClientBlocking` and validates the sync wrapper end-to-end.
 
 ## Prereqs
 
@@ -20,145 +22,145 @@ cargo run --bin kicad-ipc-cli -- help
 Ping:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- ping
+cargo run --features blocking --bin kicad-ipc-cli -- ping
 ```
 
 Version:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- version
+cargo run --features blocking --bin kicad-ipc-cli -- version
 ```
 
 Resolve KiCad binary path (default `kicad-cli`):
 
 ```bash
-cargo run --bin kicad-ipc-cli -- kicad-binary-path --binary-name kicad-cli
+cargo run --features blocking --bin kicad-ipc-cli -- kicad-binary-path --binary-name kicad-cli
 ```
 
 Resolve plugin settings path (default identifier `kicad-ipc-rust`):
 
 ```bash
-cargo run --bin kicad-ipc-cli -- plugin-settings-path --identifier kicad-ipc-rust
+cargo run --features blocking --bin kicad-ipc-cli -- plugin-settings-path --identifier kicad-ipc-rust
 ```
 
 List open PCB docs:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- open-docs --type pcb
+cargo run --features blocking --bin kicad-ipc-cli -- open-docs --type pcb
 ```
 
 Check board open:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- board-open
+cargo run --features blocking --bin kicad-ipc-cli -- board-open
 ```
 
 List nets:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- nets
+cargo run --features blocking --bin kicad-ipc-cli -- nets
 ```
 
 List project net classes:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- net-classes
+cargo run --features blocking --bin kicad-ipc-cli -- net-classes
 ```
 
 Write current net classes back with selected merge mode:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- set-net-classes --merge-mode merge
+cargo run --features blocking --bin kicad-ipc-cli -- set-net-classes --merge-mode merge
 ```
 
 List text variables for current board document:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- text-variables
+cargo run --features blocking --bin kicad-ipc-cli -- text-variables
 ```
 
 Set text variables:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- set-text-variables --merge-mode merge --var REV=A
+cargo run --features blocking --bin kicad-ipc-cli -- set-text-variables --merge-mode merge --var REV=A
 ```
 
 Expand text variables in one or more input strings:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- expand-text-variables --text "${TITLE}" --text "${REVISION}"
+cargo run --features blocking --bin kicad-ipc-cli -- expand-text-variables --text "${TITLE}" --text "${REVISION}"
 ```
 
 Measure text extents:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- text-extents --text "R1"
+cargo run --features blocking --bin kicad-ipc-cli -- text-extents --text "R1"
 ```
 
 Convert text to shape primitives:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- text-as-shapes --text "R1" --text "C5"
+cargo run --features blocking --bin kicad-ipc-cli -- text-as-shapes --text "R1" --text "C5"
 ```
 
 List enabled board layers:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- enabled-layers
+cargo run --features blocking --bin kicad-ipc-cli -- enabled-layers
 ```
 
 Set enabled board layers:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- set-enabled-layers --copper-layer-count 2 --layer-id 47 --layer-id 52
+cargo run --features blocking --bin kicad-ipc-cli -- set-enabled-layers --copper-layer-count 2 --layer-id 47 --layer-id 52
 ```
 
 Show active layer:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- active-layer
+cargo run --features blocking --bin kicad-ipc-cli -- active-layer
 ```
 
 Set active layer:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- set-active-layer --layer-id 0
+cargo run --features blocking --bin kicad-ipc-cli -- set-active-layer --layer-id 0
 ```
 
 Show visible layers:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- visible-layers
+cargo run --features blocking --bin kicad-ipc-cli -- visible-layers
 ```
 
 Set visible layers:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- set-visible-layers --layer-id 0 --layer-id 31
+cargo run --features blocking --bin kicad-ipc-cli -- set-visible-layers --layer-id 0 --layer-id 31
 ```
 
 Show board origin (grid origin by default):
 
 ```bash
-cargo run --bin kicad-ipc-cli -- board-origin
+cargo run --features blocking --bin kicad-ipc-cli -- board-origin
 ```
 
 Show drill origin:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- board-origin --type drill
+cargo run --features blocking --bin kicad-ipc-cli -- board-origin --type drill
 ```
 
 Set board origin:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- set-board-origin --type grid --x-nm 1000000 --y-nm 2000000
+cargo run --features blocking --bin kicad-ipc-cli -- set-board-origin --type grid --x-nm 1000000 --y-nm 2000000
 ```
 
 Refresh PCB editor:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- refresh-editor --frame pcb
+cargo run --features blocking --bin kicad-ipc-cli -- refresh-editor --frame pcb
 ```
 
 If your KiCad build does not expose this handler yet, this call may return `AS_UNHANDLED`.
@@ -166,226 +168,226 @@ If your KiCad build does not expose this handler yet, this call may return `AS_U
 Start a staged commit and print commit ID:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- --client-name write-test begin-commit
+cargo run --features blocking --bin kicad-ipc-cli -- --client-name write-test begin-commit
 ```
 
 End a staged commit:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- --client-name write-test end-commit --id <commit-id> --action drop --message "cli test cleanup"
+cargo run --features blocking --bin kicad-ipc-cli -- --client-name write-test end-commit --id <commit-id> --action drop --message "cli test cleanup"
 ```
 
 Save current board document:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- save-doc
+cargo run --features blocking --bin kicad-ipc-cli -- save-doc
 ```
 
 Save a copy of current board document:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- save-copy --path /tmp/example.kicad_pcb --overwrite --include-project
+cargo run --features blocking --bin kicad-ipc-cli -- save-copy --path /tmp/example.kicad_pcb --overwrite --include-project
 ```
 
 Revert current board document from disk:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- revert-doc
+cargo run --features blocking --bin kicad-ipc-cli -- revert-doc
 ```
 
 Run a raw KiCad tool action:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- run-action --action pcbnew.InteractiveSelection.ClearSelection
+cargo run --features blocking --bin kicad-ipc-cli -- run-action --action pcbnew.InteractiveSelection.ClearSelection
 ```
 
 Create raw Any item payload(s):
 
 ```bash
-cargo run --bin kicad-ipc-cli -- create-items --item type.googleapis.com/kiapi.board.types.Text=<hex_payload>
+cargo run --features blocking --bin kicad-ipc-cli -- create-items --item type.googleapis.com/kiapi.board.types.Text=<hex_payload>
 ```
 
 Update raw Any item payload(s):
 
 ```bash
-cargo run --bin kicad-ipc-cli -- update-items --item type.googleapis.com/kiapi.board.types.Text=<hex_payload>
+cargo run --features blocking --bin kicad-ipc-cli -- update-items --item type.googleapis.com/kiapi.board.types.Text=<hex_payload>
 ```
 
 Delete items by ID:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- delete-items --id <uuid> --id <uuid>
+cargo run --features blocking --bin kicad-ipc-cli -- delete-items --id <uuid> --id <uuid>
 ```
 
 Parse and create items from s-expression:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- parse-create-items --contents "(kicad_pcb (version 20240108))"
+cargo run --features blocking --bin kicad-ipc-cli -- parse-create-items --contents "(kicad_pcb (version 20240108))"
 ```
 
 Show summary of current PCB selection by item type:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- selection-summary
+cargo run --features blocking --bin kicad-ipc-cli -- selection-summary
 ```
 
 Show parsed details for currently selected items:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- selection-details
+cargo run --features blocking --bin kicad-ipc-cli -- selection-details
 ```
 
 Show raw protobuf payload bytes for selected items:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- selection-raw
+cargo run --features blocking --bin kicad-ipc-cli -- selection-raw
 ```
 
 Add items to current selection:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- add-to-selection --id <uuid> --id <uuid>
+cargo run --features blocking --bin kicad-ipc-cli -- add-to-selection --id <uuid> --id <uuid>
 ```
 
 Remove items from current selection:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- remove-from-selection --id <uuid> --id <uuid>
+cargo run --features blocking --bin kicad-ipc-cli -- remove-from-selection --id <uuid> --id <uuid>
 ```
 
 Clear current selection:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- clear-selection
+cargo run --features blocking --bin kicad-ipc-cli -- clear-selection
 ```
 
 Show pad-level netlist entries (footprint/pad/net):
 
 ```bash
-cargo run --bin kicad-ipc-cli -- netlist-pads
+cargo run --features blocking --bin kicad-ipc-cli -- netlist-pads
 ```
 
 Show parsed details for specific item IDs:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- items-by-id --id <uuid> --id <uuid>
+cargo run --features blocking --bin kicad-ipc-cli -- items-by-id --id <uuid> --id <uuid>
 ```
 
 Show item bounding boxes:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- item-bbox --id <uuid>
+cargo run --features blocking --bin kicad-ipc-cli -- item-bbox --id <uuid>
 ```
 
 Include child text in the bounding box (for items such as footprints):
 
 ```bash
-cargo run --bin kicad-ipc-cli -- item-bbox --id <uuid> --include-text
+cargo run --features blocking --bin kicad-ipc-cli -- item-bbox --id <uuid> --include-text
 ```
 
 Run hit-test on a specific item:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- hit-test --id <uuid> --x-nm <x> --y-nm <y> --tolerance-nm 0
+cargo run --features blocking --bin kicad-ipc-cli -- hit-test --id <uuid> --x-nm <x> --y-nm <y> --tolerance-nm 0
 ```
 
 List all PCB object type IDs from the proto enum:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- types-pcb
+cargo run --features blocking --bin kicad-ipc-cli -- types-pcb
 ```
 
 Dump raw item payloads for one or more PCB object type IDs:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- items-raw --type-id 11 --type-id 13 --debug
+cargo run --features blocking --bin kicad-ipc-cli -- items-raw --type-id 11 --type-id 13 --debug
 ```
 
 Dump raw payloads for all PCB object classes:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- items-raw-all-pcb --debug
+cargo run --features blocking --bin kicad-ipc-cli -- items-raw-all-pcb --debug
 ```
 
 Check whether pads/vias have flashed padstack shapes on specific layers:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- padstack-presence --item-id <uuid> --layer-id 3 --layer-id 34 --debug
+cargo run --features blocking --bin kicad-ipc-cli -- padstack-presence --item-id <uuid> --layer-id 3 --layer-id 34 --debug
 ```
 
 Get polygonized pad shape(s) on a specific layer:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- pad-shape-polygon --pad-id <uuid> --layer-id 3 --debug
+cargo run --features blocking --bin kicad-ipc-cli -- pad-shape-polygon --pad-id <uuid> --layer-id 3 --debug
 ```
 
 Dump board text (KiCad s-expression):
 
 ```bash
-cargo run --bin kicad-ipc-cli -- board-as-string
+cargo run --features blocking --bin kicad-ipc-cli -- board-as-string
 ```
 
 Dump selection text (KiCad s-expression):
 
 ```bash
-cargo run --bin kicad-ipc-cli -- selection-as-string
+cargo run --features blocking --bin kicad-ipc-cli -- selection-as-string
 ```
 
 Dump title block fields:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- title-block
+cargo run --features blocking --bin kicad-ipc-cli -- title-block
 ```
 
 Show typed stackup/graphics/appearance:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- stackup
-cargo run --bin kicad-ipc-cli -- update-stackup
-cargo run --bin kicad-ipc-cli -- graphics-defaults
-cargo run --bin kicad-ipc-cli -- appearance
+cargo run --features blocking --bin kicad-ipc-cli -- stackup
+cargo run --features blocking --bin kicad-ipc-cli -- update-stackup
+cargo run --features blocking --bin kicad-ipc-cli -- graphics-defaults
+cargo run --features blocking --bin kicad-ipc-cli -- appearance
 ```
 
 Set editor appearance:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- set-appearance --inactive-layer-display hidden --net-color-display all --board-flip normal --ratsnest-display all-layers
+cargo run --features blocking --bin kicad-ipc-cli -- set-appearance --inactive-layer-display hidden --net-color-display all --board-flip normal --ratsnest-display all-layers
 ```
 
 Inject DRC marker:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- inject-drc-error --severity error --message "API marker test" --x-nm 1000000 --y-nm 1000000
+cargo run --features blocking --bin kicad-ipc-cli -- inject-drc-error --severity error --message "API marker test" --x-nm 1000000 --y-nm 1000000
 ```
 
 Refill all zones:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- refill-zones
+cargo run --features blocking --bin kicad-ipc-cli -- refill-zones
 ```
 
 Start interactive move tool for one or more item IDs:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- interactive-move --id <uuid> --id <uuid>
+cargo run --features blocking --bin kicad-ipc-cli -- interactive-move --id <uuid> --id <uuid>
 ```
 
 Show typed netclass map:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- netclass
+cargo run --features blocking --bin kicad-ipc-cli -- netclass
 ```
 
 Print proto command coverage status (board read):
 
 ```bash
-cargo run --bin kicad-ipc-cli -- proto-coverage-board-read
+cargo run --features blocking --bin kicad-ipc-cli -- proto-coverage-board-read
 ```
 
 Generate full board-read reconstruction markdown report:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- --timeout-ms 60000 board-read-report --out docs/BOARD_READ_REPORT.md
+cargo run --features blocking --bin kicad-ipc-cli -- --timeout-ms 60000 board-read-report --out docs/BOARD_READ_REPORT.md
 ```
 
 Notes:
@@ -395,13 +397,13 @@ Notes:
 Get current project path (derived from open PCB docs):
 
 ```bash
-cargo run --bin kicad-ipc-cli -- project-path
+cargo run --features blocking --bin kicad-ipc-cli -- project-path
 ```
 
 Smoke check:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- smoke
+cargo run --features blocking --bin kicad-ipc-cli -- smoke
 ```
 
 ## Common Flags
@@ -409,25 +411,25 @@ cargo run --bin kicad-ipc-cli -- smoke
 Custom socket:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- --socket ipc:///tmp/kicad/api.sock ping
+cargo run --features blocking --bin kicad-ipc-cli -- --socket ipc:///tmp/kicad/api.sock ping
 ```
 
 Custom token:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- --token "$KICAD_API_TOKEN" version
+cargo run --features blocking --bin kicad-ipc-cli -- --token "$KICAD_API_TOKEN" version
 ```
 
 Stable client name (needed when pairing `begin-commit` and `end-commit` across separate CLI runs):
 
 ```bash
-cargo run --bin kicad-ipc-cli -- --client-name write-test begin-commit
+cargo run --features blocking --bin kicad-ipc-cli -- --client-name write-test begin-commit
 ```
 
 Custom timeout:
 
 ```bash
-cargo run --bin kicad-ipc-cli -- --timeout-ms 5000 ping
+cargo run --features blocking --bin kicad-ipc-cli -- --timeout-ms 5000 ping
 ```
 
 ## Failure Hints

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -1,22 +1,664 @@
-use crate::client::KiCadClient;
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::mpsc::{self, SyncSender};
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle, ThreadId};
+use std::time::Duration;
+
+use prost_types::Any;
+
+use crate::client::{ClientBuilder, KiCadClient};
 use crate::error::KiCadError;
+use crate::model::board::*;
+use crate::model::common::*;
+
+const BLOCKING_QUEUE_CAPACITY: usize = 64;
+
+type Job = Box<dyn FnOnce(&tokio::runtime::Runtime) + Send + 'static>;
+
+#[derive(Debug)]
+struct BlockingCore {
+    job_tx: Mutex<Option<SyncSender<Job>>>,
+    worker_thread_id: ThreadId,
+    worker_join: Mutex<Option<JoinHandle<()>>>,
+}
+
+impl BlockingCore {
+    fn start() -> Result<Arc<Self>, KiCadError> {
+        let (job_tx, job_rx) = mpsc::sync_channel::<Job>(BLOCKING_QUEUE_CAPACITY);
+        let (init_tx, init_rx) = mpsc::sync_channel::<Result<ThreadId, KiCadError>>(1);
+
+        let worker_name = format!("kicad-ipc-blocking-runtime-{}", std::process::id());
+        let worker_join = thread::Builder::new()
+            .name(worker_name)
+            .spawn(move || {
+                let runtime = match tokio::runtime::Builder::new_current_thread()
+                    .enable_time()
+                    .build()
+                {
+                    Ok(runtime) => runtime,
+                    Err(err) => {
+                        let _ = init_tx.send(Err(KiCadError::RuntimeJoin(err.to_string())));
+                        return;
+                    }
+                };
+
+                let _ = init_tx.send(Ok(thread::current().id()));
+
+                for job in job_rx {
+                    job(&runtime);
+                }
+            })
+            .map_err(|err| KiCadError::RuntimeJoin(err.to_string()))?;
+
+        let worker_thread_id = init_rx
+            .recv()
+            .map_err(|_| KiCadError::BlockingRuntimeClosed)??;
+
+        Ok(Arc::new(Self {
+            job_tx: Mutex::new(Some(job_tx)),
+            worker_thread_id,
+            worker_join: Mutex::new(Some(worker_join)),
+        }))
+    }
+
+    fn shutdown(&self) {
+        if let Ok(mut tx_guard) = self.job_tx.lock() {
+            tx_guard.take();
+        }
+
+        let handle = match self.worker_join.lock() {
+            Ok(mut guard) => guard.take(),
+            Err(_) => None,
+        };
+
+        if let Some(handle) = handle {
+            if thread::current().id() != self.worker_thread_id {
+                let _ = handle.join();
+            }
+        }
+    }
+
+    fn call<T, F>(&self, f: F) -> Result<T, KiCadError>
+    where
+        T: Send + 'static,
+        F: FnOnce(&tokio::runtime::Runtime) -> Result<T, KiCadError> + Send + 'static,
+    {
+        let sender = {
+            let guard = self
+                .job_tx
+                .lock()
+                .map_err(|_| KiCadError::BlockingRuntimeClosed)?;
+            guard
+                .as_ref()
+                .cloned()
+                .ok_or(KiCadError::BlockingRuntimeClosed)?
+        };
+
+        let (result_tx, result_rx) = mpsc::sync_channel::<Result<T, KiCadError>>(1);
+
+        sender
+            .send(Box::new(move |runtime| {
+                let result = f(runtime);
+                let _ = result_tx.send(result);
+            }))
+            .map_err(|_| KiCadError::BlockingRuntimeClosed)?;
+
+        result_rx
+            .recv()
+            .map_err(|_| KiCadError::BlockingRuntimeClosed)?
+    }
+}
+
+impl Drop for BlockingCore {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
 
 #[derive(Clone, Debug)]
 pub struct KiCadClientBlocking {
     inner: KiCadClient,
+    core: Arc<BlockingCore>,
+}
+
+#[derive(Clone, Debug)]
+pub struct KiCadClientBlockingBuilder {
+    inner: ClientBuilder,
+}
+
+impl KiCadClientBlockingBuilder {
+    pub fn new() -> Self {
+        Self {
+            inner: ClientBuilder::new(),
+        }
+    }
+
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.inner = self.inner.timeout(timeout);
+        self
+    }
+
+    pub fn socket_path(mut self, socket_path: impl Into<String>) -> Self {
+        self.inner = self.inner.socket_path(socket_path);
+        self
+    }
+
+    pub fn token(mut self, token: impl Into<String>) -> Self {
+        self.inner = self.inner.token(token);
+        self
+    }
+
+    pub fn client_name(mut self, client_name: impl Into<String>) -> Self {
+        self.inner = self.inner.client_name(client_name);
+        self
+    }
+
+    pub fn connect(self) -> Result<KiCadClientBlocking, KiCadError> {
+        let core = BlockingCore::start()?;
+        let inner_builder = self.inner;
+        let inner = core.call(move |runtime| runtime.block_on(inner_builder.connect()))?;
+
+        Ok(KiCadClientBlocking { inner, core })
+    }
+}
+
+impl Default for KiCadClientBlockingBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+macro_rules! blocking_methods {
+    (
+        $(fn $name:ident(&self $(, $arg:ident : $arg_ty:ty)*) -> $ret:ty;)+
+    ) => {
+        $(
+            pub fn $name(&self, $($arg: $arg_ty),*) -> $ret {
+                let client = self.inner.clone();
+                self.core.call(move |runtime| runtime.block_on(async move {
+                    client.$name($($arg),*).await
+                }))
+            }
+        )+
+
+        #[cfg(test)]
+        pub(crate) const GENERATED_BLOCKING_METHOD_NAMES: &'static [&'static str] = &[
+            $(stringify!($name),)+
+        ];
+    };
 }
 
 impl KiCadClientBlocking {
+    pub fn builder() -> KiCadClientBlockingBuilder {
+        KiCadClientBlockingBuilder::new()
+    }
+
     pub fn connect() -> Result<Self, KiCadError> {
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_time()
-            .build()
-            .map_err(|err| KiCadError::RuntimeJoin(err.to_string()))?;
-        let inner = runtime.block_on(KiCadClient::connect())?;
-        Ok(Self { inner })
+        KiCadClientBlockingBuilder::new().connect()
+    }
+
+    pub fn timeout(&self) -> Duration {
+        self.inner.timeout()
+    }
+
+    pub fn socket_uri(&self) -> &str {
+        self.inner.socket_uri()
     }
 
     pub fn inner(&self) -> &KiCadClient {
         &self.inner
+    }
+
+    pub fn run_action_raw(&self, action: impl Into<String>) -> Result<Any, KiCadError> {
+        let action = action.into();
+        let client = self.inner.clone();
+        self.core.call(move |runtime| {
+            runtime.block_on(async move { client.run_action_raw(action).await })
+        })
+    }
+
+    pub fn run_action(&self, action: impl Into<String>) -> Result<RunActionStatus, KiCadError> {
+        let action = action.into();
+        let client = self.inner.clone();
+        self.core
+            .call(move |runtime| runtime.block_on(async move { client.run_action(action).await }))
+    }
+
+    pub fn get_kicad_binary_path_raw(
+        &self,
+        binary_name: impl Into<String>,
+    ) -> Result<Any, KiCadError> {
+        let binary_name = binary_name.into();
+        let client = self.inner.clone();
+        self.core.call(move |runtime| {
+            runtime.block_on(async move { client.get_kicad_binary_path_raw(binary_name).await })
+        })
+    }
+
+    pub fn get_kicad_binary_path(
+        &self,
+        binary_name: impl Into<String>,
+    ) -> Result<String, KiCadError> {
+        let binary_name = binary_name.into();
+        let client = self.inner.clone();
+        self.core.call(move |runtime| {
+            runtime.block_on(async move { client.get_kicad_binary_path(binary_name).await })
+        })
+    }
+
+    pub fn get_plugin_settings_path_raw(
+        &self,
+        identifier: impl Into<String>,
+    ) -> Result<Any, KiCadError> {
+        let identifier = identifier.into();
+        let client = self.inner.clone();
+        self.core.call(move |runtime| {
+            runtime.block_on(async move { client.get_plugin_settings_path_raw(identifier).await })
+        })
+    }
+
+    pub fn get_plugin_settings_path(
+        &self,
+        identifier: impl Into<String>,
+    ) -> Result<String, KiCadError> {
+        let identifier = identifier.into();
+        let client = self.inner.clone();
+        self.core.call(move |runtime| {
+            runtime.block_on(async move { client.get_plugin_settings_path(identifier).await })
+        })
+    }
+
+    pub fn end_commit_raw(
+        &self,
+        session: CommitSession,
+        action: CommitAction,
+        message: impl Into<String>,
+    ) -> Result<Any, KiCadError> {
+        let message = message.into();
+        let client = self.inner.clone();
+        self.core.call(move |runtime| {
+            runtime.block_on(async move { client.end_commit_raw(session, action, message).await })
+        })
+    }
+
+    pub fn end_commit(
+        &self,
+        session: CommitSession,
+        action: CommitAction,
+        message: impl Into<String>,
+    ) -> Result<(), KiCadError> {
+        let message = message.into();
+        let client = self.inner.clone();
+        self.core.call(move |runtime| {
+            runtime.block_on(async move { client.end_commit(session, action, message).await })
+        })
+    }
+
+    pub fn parse_and_create_items_from_string_raw(
+        &self,
+        contents: impl Into<String>,
+    ) -> Result<Any, KiCadError> {
+        let contents = contents.into();
+        let client = self.inner.clone();
+        self.core.call(move |runtime| {
+            runtime.block_on(async move {
+                client
+                    .parse_and_create_items_from_string_raw(contents)
+                    .await
+            })
+        })
+    }
+
+    pub fn parse_and_create_items_from_string(
+        &self,
+        contents: impl Into<String>,
+    ) -> Result<Vec<Any>, KiCadError> {
+        let contents = contents.into();
+        let client = self.inner.clone();
+        self.core.call(move |runtime| {
+            runtime
+                .block_on(async move { client.parse_and_create_items_from_string(contents).await })
+        })
+    }
+
+    pub fn inject_drc_error_raw(
+        &self,
+        severity: DrcSeverity,
+        message: impl Into<String>,
+        position: Option<Vector2Nm>,
+        item_ids: Vec<String>,
+    ) -> Result<Any, KiCadError> {
+        let message = message.into();
+        let client = self.inner.clone();
+        self.core.call(move |runtime| {
+            runtime.block_on(async move {
+                client
+                    .inject_drc_error_raw(severity, message, position, item_ids)
+                    .await
+            })
+        })
+    }
+
+    pub fn inject_drc_error(
+        &self,
+        severity: DrcSeverity,
+        message: impl Into<String>,
+        position: Option<Vector2Nm>,
+        item_ids: Vec<String>,
+    ) -> Result<Option<String>, KiCadError> {
+        let message = message.into();
+        let client = self.inner.clone();
+        self.core.call(move |runtime| {
+            runtime.block_on(async move {
+                client
+                    .inject_drc_error(severity, message, position, item_ids)
+                    .await
+            })
+        })
+    }
+
+    pub fn save_copy_of_document_raw(
+        &self,
+        path: impl Into<String>,
+        overwrite: bool,
+        include_project: bool,
+    ) -> Result<Any, KiCadError> {
+        let path = path.into();
+        let client = self.inner.clone();
+        self.core.call(move |runtime| {
+            runtime.block_on(async move {
+                client
+                    .save_copy_of_document_raw(path, overwrite, include_project)
+                    .await
+            })
+        })
+    }
+
+    pub fn save_copy_of_document(
+        &self,
+        path: impl Into<String>,
+        overwrite: bool,
+        include_project: bool,
+    ) -> Result<(), KiCadError> {
+        let path = path.into();
+        let client = self.inner.clone();
+        self.core.call(move |runtime| {
+            runtime.block_on(async move {
+                client
+                    .save_copy_of_document(path, overwrite, include_project)
+                    .await
+            })
+        })
+    }
+
+    blocking_methods! {
+        fn ping(&self) -> Result<(), KiCadError>;
+        fn refresh_editor(&self, frame: EditorFrameType) -> Result<(), KiCadError>;
+        fn get_version(&self) -> Result<VersionInfo, KiCadError>;
+        fn get_open_documents(&self, document_type: DocumentType) -> Result<Vec<DocumentSpecifier>, KiCadError>;
+        fn get_net_classes_raw(&self) -> Result<Any, KiCadError>;
+        fn get_net_classes(&self) -> Result<Vec<NetClassInfo>, KiCadError>;
+        fn set_net_classes_raw(&self, net_classes: Vec<NetClassInfo>, merge_mode: MapMergeMode) -> Result<Any, KiCadError>;
+        fn set_net_classes(&self, net_classes: Vec<NetClassInfo>, merge_mode: MapMergeMode) -> Result<Vec<NetClassInfo>, KiCadError>;
+        fn get_text_variables_raw(&self) -> Result<Any, KiCadError>;
+        fn get_text_variables(&self) -> Result<BTreeMap<String, String>, KiCadError>;
+        fn set_text_variables_raw(&self, variables: BTreeMap<String, String>, merge_mode: MapMergeMode) -> Result<Any, KiCadError>;
+        fn set_text_variables(&self, variables: BTreeMap<String, String>, merge_mode: MapMergeMode) -> Result<BTreeMap<String, String>, KiCadError>;
+        fn expand_text_variables_raw(&self, text: Vec<String>) -> Result<Any, KiCadError>;
+        fn expand_text_variables(&self, text: Vec<String>) -> Result<Vec<String>, KiCadError>;
+        fn get_text_extents_raw(&self, text: TextSpec) -> Result<Any, KiCadError>;
+        fn get_text_extents(&self, text: TextSpec) -> Result<TextExtents, KiCadError>;
+        fn get_text_as_shapes_raw(&self, text: Vec<TextObjectSpec>) -> Result<Any, KiCadError>;
+        fn get_text_as_shapes(&self, text: Vec<TextObjectSpec>) -> Result<Vec<TextAsShapesEntry>, KiCadError>;
+        fn get_current_project_path(&self) -> Result<PathBuf, KiCadError>;
+        fn has_open_board(&self) -> Result<bool, KiCadError>;
+        fn begin_commit_raw(&self) -> Result<Any, KiCadError>;
+        fn begin_commit(&self) -> Result<CommitSession, KiCadError>;
+        fn create_items_raw(&self, items: Vec<Any>, container_id: Option<String>) -> Result<Any, KiCadError>;
+        fn create_items(&self, items: Vec<Any>, container_id: Option<String>) -> Result<Vec<Any>, KiCadError>;
+        fn update_items_raw(&self, items: Vec<Any>) -> Result<Any, KiCadError>;
+        fn update_items(&self, items: Vec<Any>) -> Result<Vec<Any>, KiCadError>;
+        fn delete_items_raw(&self, item_ids: Vec<String>) -> Result<Any, KiCadError>;
+        fn delete_items(&self, item_ids: Vec<String>) -> Result<Vec<String>, KiCadError>;
+        fn get_nets(&self) -> Result<Vec<BoardNet>, KiCadError>;
+        fn get_board_enabled_layers(&self) -> Result<BoardEnabledLayers, KiCadError>;
+        fn set_board_enabled_layers(&self, copper_layer_count: u32, layer_ids: Vec<i32>) -> Result<BoardEnabledLayers, KiCadError>;
+        fn get_active_layer(&self) -> Result<BoardLayerInfo, KiCadError>;
+        fn set_active_layer(&self, layer_id: i32) -> Result<(), KiCadError>;
+        fn get_visible_layers(&self) -> Result<Vec<BoardLayerInfo>, KiCadError>;
+        fn set_visible_layers(&self, layer_ids: Vec<i32>) -> Result<(), KiCadError>;
+        fn get_board_origin(&self, kind: BoardOriginKind) -> Result<Vector2Nm, KiCadError>;
+        fn set_board_origin(&self, kind: BoardOriginKind, origin: Vector2Nm) -> Result<(), KiCadError>;
+        fn get_selection_summary(&self) -> Result<SelectionSummary, KiCadError>;
+        fn get_selection_raw(&self) -> Result<Vec<Any>, KiCadError>;
+        fn get_selection_details(&self) -> Result<Vec<SelectionItemDetail>, KiCadError>;
+        fn get_selection(&self) -> Result<Vec<PcbItem>, KiCadError>;
+        fn add_to_selection_raw(&self, item_ids: Vec<String>) -> Result<Vec<Any>, KiCadError>;
+        fn add_to_selection(&self, item_ids: Vec<String>) -> Result<SelectionSummary, KiCadError>;
+        fn clear_selection_raw(&self) -> Result<Vec<Any>, KiCadError>;
+        fn clear_selection(&self) -> Result<SelectionSummary, KiCadError>;
+        fn remove_from_selection_raw(&self, item_ids: Vec<String>) -> Result<Vec<Any>, KiCadError>;
+        fn remove_from_selection(&self, item_ids: Vec<String>) -> Result<SelectionSummary, KiCadError>;
+        fn get_pad_netlist(&self) -> Result<Vec<PadNetEntry>, KiCadError>;
+        fn get_items_raw_by_type_codes(&self, type_codes: Vec<i32>) -> Result<Vec<Any>, KiCadError>;
+        fn get_items_details_by_type_codes(&self, type_codes: Vec<i32>) -> Result<Vec<SelectionItemDetail>, KiCadError>;
+        fn get_items_by_type_codes(&self, type_codes: Vec<i32>) -> Result<Vec<PcbItem>, KiCadError>;
+        fn get_all_pcb_items_raw(&self) -> Result<Vec<(PcbObjectTypeCode, Vec<Any>)>, KiCadError>;
+        fn get_all_pcb_items_details(&self) -> Result<Vec<(PcbObjectTypeCode, Vec<SelectionItemDetail>)>, KiCadError>;
+        fn get_all_pcb_items(&self) -> Result<Vec<(PcbObjectTypeCode, Vec<PcbItem>)>, KiCadError>;
+        fn get_items_by_net_raw(&self, type_codes: Vec<i32>, net_codes: Vec<i32>) -> Result<Vec<Any>, KiCadError>;
+        fn get_items_by_net(&self, type_codes: Vec<i32>, net_codes: Vec<i32>) -> Result<Vec<PcbItem>, KiCadError>;
+        fn get_items_by_net_class_raw(&self, type_codes: Vec<i32>, net_classes: Vec<String>) -> Result<Vec<Any>, KiCadError>;
+        fn get_items_by_net_class(&self, type_codes: Vec<i32>, net_classes: Vec<String>) -> Result<Vec<PcbItem>, KiCadError>;
+        fn get_netclass_for_nets_raw(&self, nets: Vec<BoardNet>) -> Result<Any, KiCadError>;
+        fn get_netclass_for_nets(&self, nets: Vec<BoardNet>) -> Result<Vec<NetClassForNetEntry>, KiCadError>;
+        fn refill_zones(&self, zone_ids: Vec<String>) -> Result<(), KiCadError>;
+        fn get_pad_shape_as_polygon_raw(&self, pad_ids: Vec<String>, layer_id: i32) -> Result<Vec<Any>, KiCadError>;
+        fn get_pad_shape_as_polygon(&self, pad_ids: Vec<String>, layer_id: i32) -> Result<Vec<PadShapeAsPolygonEntry>, KiCadError>;
+        fn check_padstack_presence_on_layers_raw(&self, item_ids: Vec<String>, layer_ids: Vec<i32>) -> Result<Vec<Any>, KiCadError>;
+        fn check_padstack_presence_on_layers(&self, item_ids: Vec<String>, layer_ids: Vec<i32>) -> Result<Vec<PadstackPresenceEntry>, KiCadError>;
+        fn get_board_stackup_raw(&self) -> Result<Any, KiCadError>;
+        fn get_board_stackup(&self) -> Result<BoardStackup, KiCadError>;
+        fn update_board_stackup_raw(&self, stackup: BoardStackup) -> Result<Any, KiCadError>;
+        fn update_board_stackup(&self, stackup: BoardStackup) -> Result<BoardStackup, KiCadError>;
+        fn get_graphics_defaults_raw(&self) -> Result<Any, KiCadError>;
+        fn get_graphics_defaults(&self) -> Result<GraphicsDefaults, KiCadError>;
+        fn get_board_editor_appearance_settings_raw(&self) -> Result<Any, KiCadError>;
+        fn get_board_editor_appearance_settings(&self) -> Result<BoardEditorAppearanceSettings, KiCadError>;
+        fn set_board_editor_appearance_settings(&self, settings: BoardEditorAppearanceSettings) -> Result<BoardEditorAppearanceSettings, KiCadError>;
+        fn interactive_move_items_raw(&self, item_ids: Vec<String>) -> Result<Any, KiCadError>;
+        fn interactive_move_items(&self, item_ids: Vec<String>) -> Result<(), KiCadError>;
+        fn get_title_block_info(&self) -> Result<TitleBlockInfo, KiCadError>;
+        fn save_document_raw(&self) -> Result<Any, KiCadError>;
+        fn save_document(&self) -> Result<(), KiCadError>;
+        fn revert_document_raw(&self) -> Result<Any, KiCadError>;
+        fn revert_document(&self) -> Result<(), KiCadError>;
+        fn get_board_as_string(&self) -> Result<String, KiCadError>;
+        fn get_selection_as_string(&self) -> Result<String, KiCadError>;
+        fn get_items_by_id_raw(&self, item_ids: Vec<String>) -> Result<Vec<Any>, KiCadError>;
+        fn get_items_by_id_details(&self, item_ids: Vec<String>) -> Result<Vec<SelectionItemDetail>, KiCadError>;
+        fn get_items_by_id(&self, item_ids: Vec<String>) -> Result<Vec<PcbItem>, KiCadError>;
+        fn get_item_bounding_boxes(&self, item_ids: Vec<String>, include_child_text: bool) -> Result<Vec<ItemBoundingBox>, KiCadError>;
+        fn hit_test_item(&self, item_id: String, position: Vector2Nm, tolerance_nm: i32) -> Result<ItemHitTestResult, KiCadError>;
+    }
+
+    #[cfg(test)]
+    pub(crate) const MANUAL_BLOCKING_METHOD_NAMES: &'static [&'static str] = &[
+        "connect",
+        "run_action_raw",
+        "run_action",
+        "get_kicad_binary_path_raw",
+        "get_kicad_binary_path",
+        "get_plugin_settings_path_raw",
+        "get_plugin_settings_path",
+        "end_commit_raw",
+        "end_commit",
+        "parse_and_create_items_from_string_raw",
+        "parse_and_create_items_from_string",
+        "inject_drc_error_raw",
+        "inject_drc_error",
+        "save_copy_of_document_raw",
+        "save_copy_of_document",
+    ];
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+    use std::sync::mpsc as std_mpsc;
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn blocking_core_executes_job_and_returns_result() {
+        let core = BlockingCore::start().expect("blocking core must start");
+        let value = core
+            .call(|_| Ok::<_, KiCadError>(1234))
+            .expect("blocking job should execute");
+        assert_eq!(value, 1234);
+    }
+
+    #[test]
+    fn blocking_core_handles_concurrent_submitters() {
+        let core = BlockingCore::start().expect("blocking core must start");
+        let mut handles = Vec::new();
+
+        for idx in 0..8 {
+            let core = Arc::clone(&core);
+            handles.push(thread::spawn(move || {
+                core.call(move |_| Ok::<_, KiCadError>(idx * 2))
+                    .expect("job should return");
+            }));
+        }
+
+        for handle in handles {
+            handle.join().expect("submitter thread must join");
+        }
+    }
+
+    #[test]
+    fn blocking_core_shutdown_drains_inflight_jobs() {
+        let core = BlockingCore::start().expect("blocking core must start");
+        let (started_tx, started_rx) = std_mpsc::sync_channel::<()>(1);
+
+        let core_for_call = Arc::clone(&core);
+        let worker = thread::spawn(move || {
+            core_for_call
+                .call(move |_| {
+                    let _ = started_tx.send(());
+                    thread::sleep(Duration::from_millis(120));
+                    Ok::<_, KiCadError>(())
+                })
+                .expect("in-flight job should complete");
+        });
+
+        started_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("job should begin");
+
+        let begin = Instant::now();
+        core.shutdown();
+        let elapsed = begin.elapsed();
+
+        assert!(
+            elapsed >= Duration::from_millis(80),
+            "shutdown should wait for in-flight job; elapsed: {elapsed:?}"
+        );
+
+        worker.join().expect("worker submitter should join");
+    }
+
+    #[test]
+    fn blocking_core_returns_closed_error_after_shutdown() {
+        let core = BlockingCore::start().expect("blocking core must start");
+        core.shutdown();
+
+        let err = core
+            .call(|_| Ok::<_, KiCadError>(()))
+            .expect_err("closed core should reject calls");
+        assert!(matches!(err, KiCadError::BlockingRuntimeClosed));
+    }
+
+    #[test]
+    fn sync_wrapper_covers_async_method_names() {
+        let mut async_methods = BTreeSet::new();
+        for line in include_str!("client.rs").lines() {
+            let trimmed = line.trim_start();
+            if let Some(rest) = trimmed.strip_prefix("pub async fn ") {
+                if let Some(name) = rest.split('(').next() {
+                    async_methods.insert(name.trim().to_string());
+                }
+            }
+        }
+
+        let blocking_methods: BTreeSet<String> =
+            KiCadClientBlocking::GENERATED_BLOCKING_METHOD_NAMES
+                .iter()
+                .chain(KiCadClientBlocking::MANUAL_BLOCKING_METHOD_NAMES.iter())
+                .map(|name| (*name).to_string())
+                .collect();
+
+        let missing: Vec<String> = async_methods
+            .into_iter()
+            .filter(|name| !blocking_methods.contains(name))
+            .collect();
+
+        assert!(
+            missing.is_empty(),
+            "missing blocking wrappers for async methods: {:?}",
+            missing
+        );
+    }
+
+    #[test]
+    fn impl_into_string_wrapper_signatures_accept_str() {
+        fn assert_signatures(client: &KiCadClientBlocking) {
+            let _ = client.run_action_raw("pcbnew.Refresh");
+            let _ = client.run_action("pcbnew.Refresh");
+            let _ = client.get_kicad_binary_path_raw("kicad-cli");
+            let _ = client.get_kicad_binary_path("kicad-cli");
+            let _ = client.get_plugin_settings_path_raw("kicad-ipc-rs");
+            let _ = client.get_plugin_settings_path("kicad-ipc-rs");
+            let _ = client.end_commit_raw(
+                CommitSession {
+                    id: "commit-id".to_string(),
+                },
+                CommitAction::Drop,
+                "test",
+            );
+            let _ = client.end_commit(
+                CommitSession {
+                    id: "commit-id".to_string(),
+                },
+                CommitAction::Drop,
+                "test",
+            );
+            let _ = client.parse_and_create_items_from_string_raw("(kicad_pcb)");
+            let _ = client.parse_and_create_items_from_string("(kicad_pcb)");
+            let _ = client.inject_drc_error_raw(DrcSeverity::Warning, "marker", None, Vec::new());
+            let _ = client.inject_drc_error(DrcSeverity::Warning, "marker", None, Vec::new());
+            let _ = client.save_copy_of_document_raw("/tmp/example.kicad_pcb", false, false);
+            let _ = client.save_copy_of_document("/tmp/example.kicad_pcb", false, false);
+        }
+
+        let _ = assert_signatures as fn(&KiCadClientBlocking);
+    }
+
+    #[test]
+    fn blocking_smoke_live_when_socket_env_is_set() {
+        if std::env::var("KICAD_API_SOCKET").is_err() {
+            return;
+        }
+
+        let client = KiCadClientBlocking::connect().expect("blocking client should connect");
+        client.ping().expect("ping should succeed");
+        let _ = client.get_version().expect("version should succeed");
+        let _ = client
+            .get_open_documents(DocumentType::Pcb)
+            .expect("open docs should succeed");
+        let _ = client
+            .get_visible_layers()
+            .expect("board read method should succeed");
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -52,6 +52,9 @@ pub enum KiCadError {
     #[error("runtime task join failed: {0}")]
     RuntimeJoin(String),
 
+    #[error("blocking runtime is unavailable")]
+    BlockingRuntimeClosed,
+
     #[error("mutex poisoned")]
     InternalPoisoned,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,8 @@ pub mod blocking;
 
 pub(crate) mod proto;
 
+#[cfg(feature = "blocking")]
+pub use crate::blocking::{KiCadClientBlocking, KiCadClientBlockingBuilder};
 pub use crate::client::{ClientBuilder, KiCadClient};
 pub use crate::error::KiCadError;
 pub use crate::kicad_api_version::KICAD_API_VERSION;


### PR DESCRIPTION
## Summary
- implement `KiCadClientBlocking` as a full sync facade over async `KiCadClient` using a dedicated Tokio runtime thread and serialized request queue
- add blocking builder parity (`timeout`, `socket_path`, `token`, `client_name`, `connect`) and runtime closure error variant (`BlockingRuntimeClosed`)
- generate blocking wrappers for async method parity and add parity + blocking core tests
- migrate `kicad-ipc-cli` to sync client usage and wire it as a Cargo bin behind the `blocking` feature
- update README with async-default and blocking usage examples, and update CLI runbook commands for blocking feature

## Validation
- `cargo fmt --all --check`
- `cargo test --all-features`
- `cargo check --all-features`
- `cargo package --allow-dirty`
- local live KiCad reads/writes via `cargo run --features blocking --bin kicad-ipc-cli -- ...` (including new track/via create + update + readback)
