### PR TITLE
feat: expose via layer spans in typed model and CLI

### DIFF
--- a/docs/TEST_CLI.md
+++ b/docs/TEST_CLI.md
@@ -61,6 +61,12 @@ List nets:
 cargo run --features blocking --bin kicad-ipc-cli -- nets
 ```
 
+List vias with typed via kind and layer span:
+
+```bash
+cargo run --features blocking --bin kicad-ipc-cli -- vias
+```
+
 List project net classes:
 
 ```bash

--- a/docs/slash-commands/StandardChecks.md
+++ b/docs/slash-commands/StandardChecks.md
@@ -1,0 +1,32 @@
+# /StandardChecks
+
+Use for any feature/change in this repo.
+
+## Required Flow
+
+1. Confirm low-level proto fields and comments for new/changed behavior.
+2. Map into typed model structs (async path) with explicit absence handling (`Option`) and unknown-enum handling (`Unknown(...)` / `UNKNOWN_LAYER(...)`).
+3. Update sync/blocking parity (`KiCadClientBlocking`) for any new async methods.
+4. Update CLI surface (`test-scripts/kicad-ipc-cli.rs`) so feature is observable from terminal.
+5. Add regression tests:
+   - decode/mapping test(s)
+   - CLI arg parse test(s) for new command/flags
+   - detail/format test(s) if output changed
+6. Update docs touched by behavior/API (`README.md`, `docs/TEST_CLI.md`, runbooks as needed).
+7. Run checks:
+   - `cargo fmt --all`
+   - `cargo test`
+   - `cargo test --features blocking`
+8. Live verify with KiCad open (real socket): run CLI command(s) showing new data path and confirm expected fields.
+9. Ship:
+   - `git status`
+   - commit with Conventional Commit
+   - push branch
+   - open PR
+   - request review with `@codex review`.
+
+## Output Expectations
+
+- Include exact file refs + what changed.
+- Include command outputs summary for tests/live run.
+- Call out any skipped checks with reason.

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -441,6 +441,8 @@ impl KiCadClientBlocking {
         fn remove_from_selection_raw(&self, item_ids: Vec<String>) -> Result<Vec<Any>, KiCadError>;
         fn remove_from_selection(&self, item_ids: Vec<String>) -> Result<SelectionSummary, KiCadError>;
         fn get_pad_netlist(&self) -> Result<Vec<PadNetEntry>, KiCadError>;
+        fn get_vias_raw(&self) -> Result<Vec<Any>, KiCadError>;
+        fn get_vias(&self) -> Result<Vec<PcbVia>, KiCadError>;
         fn get_items_raw_by_type_codes(&self, type_codes: Vec<i32>) -> Result<Vec<Any>, KiCadError>;
         fn get_items_details_by_type_codes(&self, type_codes: Vec<i32>) -> Result<Vec<SelectionItemDetail>, KiCadError>;
         fn get_items_by_type_codes(&self, type_codes: Vec<i32>) -> Result<Vec<PcbItem>, KiCadError>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,9 +32,9 @@ pub use crate::model::board::{
     NetClassForNetEntry, NetClassInfo, NetClassType, NetColorDisplayMode, PadNetEntry,
     PadShapeAsPolygonEntry, PadstackPresenceEntry, PadstackPresenceState, PcbArc,
     PcbBoardGraphicShape, PcbBoardText, PcbBoardTextBox, PcbDimension, PcbField, PcbFootprint,
-    PcbGroup, PcbItem, PcbPad, PcbPadType, PcbTrack, PcbUnknownItem, PcbVia, PcbViaType, PcbZone,
-    PcbZoneType, PolyLineNm, PolyLineNodeGeometryNm, PolygonWithHolesNm, RatsnestDisplayMode,
-    Vector2Nm,
+    PcbGroup, PcbItem, PcbPad, PcbPadType, PcbTrack, PcbUnknownItem, PcbVia, PcbViaLayers,
+    PcbViaType, PcbZone, PcbZoneType, PolyLineNm, PolyLineNodeGeometryNm, PolygonWithHolesNm,
+    RatsnestDisplayMode, Vector2Nm,
 };
 pub use crate::model::common::{
     CommitAction, CommitSession, DocumentSpecifier, DocumentType, EditorFrameType, ItemBoundingBox,

--- a/src/model/board.rs
+++ b/src/model/board.rs
@@ -326,6 +326,13 @@ pub enum PcbViaType {
     Unknown(i32),
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PcbViaLayers {
+    pub padstack_layers: Vec<BoardLayerInfo>,
+    pub drill_start_layer: Option<BoardLayerInfo>,
+    pub drill_end_layer: Option<BoardLayerInfo>,
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum PcbPadType {
     Pth,
@@ -370,6 +377,7 @@ pub struct PcbVia {
     pub id: Option<String>,
     pub position_nm: Option<Vector2Nm>,
     pub via_type: PcbViaType,
+    pub layers: Option<PcbViaLayers>,
     pub net: Option<BoardNet>,
 }
 


### PR DESCRIPTION
## Summary
- add `PcbViaLayers` and expose via layer span data on `PcbVia` (`layers: Option<PcbViaLayers>`)
- map via padstack/drill layers from protobuf into typed model
- extend selection detail formatting to include padstack layers + drill span
- add async + blocking convenience methods: `get_vias_raw` and `get_vias`
- add CLI command `vias` to print via type, pad layers, and drill span
- add repo slash command doc `/StandardChecks` under `docs/slash-commands/StandardChecks.md`

## Tests
- `cargo fmt --all`
- `cargo test`
- `cargo test --features blocking`
- live CLI check with KiCad board open:
  - `cargo run --features blocking --bin kicad-ipc-cli -- board-open`
  - `cargo run --features blocking --bin kicad-ipc-cli -- vias`
