### PR TITLE
ci: fix release-plz workflow for auto release on main

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,14 +1,37 @@
-            - name: release-plz
-  # You may pin to the exact commit or the version.
-  # uses: release-plz/action@3e097c27f0fb2124b5addd6f2dd463884a3938ec
-  uses: release-plz/action@v0.5.2
-  with:
-    # The release-plz command to run. Accepted values: `release-pr`, `release`. If unspecified, this action runs both these commands.
-    command: # optional
-    # Registry where the packages are stored. The registry name needs to be present in the Cargo config. If unspecified, crates.io is used.
-    registry: # optional
-    # Path to the Cargo.toml of the project you want to update. If not provided, release-plz will use the Cargo.toml of the root directory. Both Cargo workspaces and single packages are supported.
-    project_manifest: # optional
-    # Release-plz version to use. It must be an existing git tag name. For example `release-plz-v0.2.45`. (Default: `latest`).
-    version: # optional, default is release-plz-v0.3.3
-          
+name: release-plz
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-plz:
+    name: release-plz release
+    runs-on: ubuntu-latest
+    environment: CRATE_RELEASE
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -34,4 +34,4 @@ jobs:
           command: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || vars.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -6,32 +6,49 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
-  release-plz:
+  release-plz-release:
     name: release-plz release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     environment: CRATE_RELEASE
-    concurrency:
-      group: release-plz-${{ github.ref }}
-      cancel-in-progress: false
     steps:
-      - name: Checkout repository
+      - &checkout
+        name: Checkout repository
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Install Rust toolchain
+      - &install-rust
+        name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Run release-plz
         uses: release-plz/action@v0.5
         with:
           command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || vars.CARGO_REGISTRY_TOKEN }}
+
+  release-plz-pr:
+    name: release-plz PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - *checkout
+      - *install-rust
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || vars.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,14 @@
+            - name: release-plz
+  # You may pin to the exact commit or the version.
+  # uses: release-plz/action@3e097c27f0fb2124b5addd6f2dd463884a3938ec
+  uses: release-plz/action@v0.5.2
+  with:
+    # The release-plz command to run. Accepted values: `release-pr`, `release`. If unspecified, this action runs both these commands.
+    command: # optional
+    # Registry where the packages are stored. The registry name needs to be present in the Cargo config. If unspecified, crates.io is used.
+    registry: # optional
+    # Path to the Cargo.toml of the project you want to update. If not provided, release-plz will use the Cargo.toml of the root directory. Both Cargo workspaces and single packages are supported.
+    project_manifest: # optional
+    # Release-plz version to use. It must be an existing git tag name. For example `release-plz-v0.2.45`. (Default: `latest`).
+    version: # optional, default is release-plz-v0.3.3
+          

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,5 @@
+[workspace]
+release_always = true
+git_tag_enable = true
+git_release_enable = true
+publish = true

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -3,3 +3,4 @@ release_always = true
 git_tag_enable = true
 git_release_enable = true
 publish = true
+release_commits = '^(feat|fix|perf|refactor|revert|build)(\([^)]+\))?(!)?:'


### PR DESCRIPTION
## Summary
- replace invalid release-plz snippet with a valid GitHub Actions workflow
- run on every push to `main` (plus manual dispatch)
- add two release-plz jobs:
  - `release` (publishes/tag/release)
  - `release-pr` (keeps version/changelog release PR updated)
- attach release job to `CRATE_RELEASE` environment
- support crates token from either environment secret or environment variable:
  - `${{ secrets.CARGO_REGISTRY_TOKEN || vars.CARGO_REGISTRY_TOKEN }}`
- add `release-plz.toml` with:
  - `release_always = true`
  - `git_tag_enable = true`
  - `git_release_enable = true`
  - `publish = true`
  - `release_commits` filter so `docs:` / `ci:` / `chore:` commits do not trigger version updates

## Result
- Conventional-commit release policy now focuses on user-impacting changes (`feat|fix|perf|refactor|revert|build`).
- Git tag + GitHub release creation is explicitly enabled in config.
