### PR TITLE
ci: gate release job on release-pr output

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,14 +1,37 @@
-            - name: release-plz
-  # You may pin to the exact commit or the version.
-  # uses: release-plz/action@3e097c27f0fb2124b5addd6f2dd463884a3938ec
-  uses: release-plz/action@v0.5.2
-  with:
-    # The release-plz command to run. Accepted values: `release-pr`, `release`. If unspecified, this action runs both these commands.
-    command: # optional
-    # Registry where the packages are stored. The registry name needs to be present in the Cargo config. If unspecified, crates.io is used.
-    registry: # optional
-    # Path to the Cargo.toml of the project you want to update. If not provided, release-plz will use the Cargo.toml of the root directory. Both Cargo workspaces and single packages are supported.
-    project_manifest: # optional
-    # Release-plz version to use. It must be an existing git tag name. For example `release-plz-v0.2.45`. (Default: `latest`).
-    version: # optional, default is release-plz-v0.3.3
-          
+name: release-plz
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-plz:
+    name: release-plz release
+    runs-on: ubuntu-latest
+    environment: CRATE_RELEASE
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -34,4 +34,4 @@ jobs:
           command: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || vars.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -7,12 +7,17 @@ on:
   workflow_dispatch:
 
 jobs:
-  release-plz-release:
-    name: release-plz release
+  release-plz-pr:
+    name: release-plz PR
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    environment: CRATE_RELEASE
+      pull-requests: write
+    outputs:
+      prs_created: ${{ steps.release-plz.outputs.prs_created }}
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
     steps:
       - &checkout
         name: Checkout repository
@@ -26,29 +31,28 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Run release-plz
+        id: release-plz
         uses: release-plz/action@v0.5
         with:
-          command: release
+          command: release-pr
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || vars.CARGO_REGISTRY_TOKEN }}
 
-  release-plz-pr:
-    name: release-plz PR
+  release-plz-release:
+    name: release-plz release
     runs-on: ubuntu-latest
+    needs: [release-plz-pr]
+    if: needs.release-plz-pr.outputs.prs_created != 'true'
     permissions:
       contents: write
-      pull-requests: write
-    concurrency:
-      group: release-plz-${{ github.ref }}
-      cancel-in-progress: false
+    environment: CRATE_RELEASE
     steps:
       - *checkout
       - *install-rust
       - name: Run release-plz
         uses: release-plz/action@v0.5
         with:
-          command: release-pr
+          command: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || vars.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -6,32 +6,49 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
-  release-plz:
+  release-plz-release:
     name: release-plz release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     environment: CRATE_RELEASE
-    concurrency:
-      group: release-plz-${{ github.ref }}
-      cancel-in-progress: false
     steps:
-      - name: Checkout repository
+      - &checkout
+        name: Checkout repository
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Install Rust toolchain
+      - &install-rust
+        name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Run release-plz
         uses: release-plz/action@v0.5
         with:
           command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || vars.CARGO_REGISTRY_TOKEN }}
+
+  release-plz-pr:
+    name: release-plz PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - *checkout
+      - *install-rust
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || vars.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,14 @@
+            - name: release-plz
+  # You may pin to the exact commit or the version.
+  # uses: release-plz/action@3e097c27f0fb2124b5addd6f2dd463884a3938ec
+  uses: release-plz/action@v0.5.2
+  with:
+    # The release-plz command to run. Accepted values: `release-pr`, `release`. If unspecified, this action runs both these commands.
+    command: # optional
+    # Registry where the packages are stored. The registry name needs to be present in the Cargo config. If unspecified, crates.io is used.
+    registry: # optional
+    # Path to the Cargo.toml of the project you want to update. If not provided, release-plz will use the Cargo.toml of the root directory. Both Cargo workspaces and single packages are supported.
+    project_manifest: # optional
+    # Release-plz version to use. It must be an existing git tag name. For example `release-plz-v0.2.45`. (Default: `latest`).
+    version: # optional, default is release-plz-v0.3.3
+          

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,5 @@
+[workspace]
+release_always = true
+git_tag_enable = true
+git_release_enable = true
+publish = true

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -3,3 +3,4 @@ release_always = true
 git_tag_enable = true
 git_release_enable = true
 publish = true
+release_commits = '^(feat|fix|perf|refactor|revert|build)(\([^)]+\))?(!)?:'


### PR DESCRIPTION
## Summary
- make `release-plz release` wait for `release-plz PR`
- skip release job when a release PR was created in the same run
- remove `CARGO_REGISTRY_TOKEN` from the `release-pr` job

## Why
Without this, a push to `main` can run release job before the release PR is merged, causing a no-op run.
