### PR TITLE
fix(ci): stop ignoring tracked docs/book files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,9 @@ target
 prompts/
 
 *.DS_Store
-book/
+
+# mdBook build output at repo root
+/book/
+# Keep docs/book source tracked
+!docs/book/
+!docs/book/**


### PR DESCRIPTION
## Summary
- narrow mdBook ignore from `book/` to `/book/`
- explicitly unignore `docs/book/**` so tracked docs are never treated as ignored

## Why
`release-plz` fails with a dirty working tree when tracked files under `docs/book/` match `.gitignore` rule `book/`.

## Validation
- `git check-ignore -v --non-matching book/index.html docs/book/book.toml docs/book/src/intro.md`
