### PR TITLE
fix: use named pipe probe for IPC availability on Windows

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -4225,6 +4225,20 @@ fn ipc_path_from_uri(socket_uri: &str) -> Option<PathBuf> {
 
 fn is_missing_ipc_socket(socket_uri: &str) -> bool {
     if let Some(path) = ipc_path_from_uri(socket_uri) {
+        #[cfg(target_os = "windows")]
+        {
+            // On Windows, nng's ipc:// transport uses named pipes, not filesystem
+            // sockets. A path.exists() check is always false even when KiCad is
+            // running. Instead, probe the named pipe directly: a successful open
+            // or ERROR_PIPE_BUSY (231) both mean a server is listening.
+            let pipe_path = format!(r"\\.\pipe\{}", path.display());
+            return match std::fs::OpenOptions::new().read(true).open(&pipe_path) {
+                Ok(_) => false,
+                Err(e) => e.raw_os_error() != Some(231),
+            };
+        }
+
+        #[cfg(not(target_os = "windows"))]
         return !path.exists();
     }
 


### PR DESCRIPTION
On Windows 11, the ipc transport is backed by _named pipes,_ not filesystem sockets.
Therefore, the pre-flight check "is_missing_ipc_socket" fails because no file exists - yet the socket is listening.

## Why it is broken right now:
The socket path is normalized with an ipc:// prefix.
The prefix is then stripped in ipc_path_from_uri - leaving a file path.

Then, a test is done:
    if let Some(path) = ipc_path_from_uri(socket_uri) {
        return !path.exists();
    }

This will always fail in windows since KiCAD does not create a api.sock file, nor does windows.

Proof:
Here, the socket URI is "ipc://C:\Users\micro\AppData\Local\Temp\kicad\api.sock"

> ls C:\Users\micro\AppData\Local\Temp\kicad
=> Nothing!

Yet, the socket exists:
Get-ChildItem \\.\pipe\ | Where-Object {$_.Name -eq "C:\Users\micro\AppData\Local\Temp\kicad\api.sock"}

    Directory: C:\Users\micro\AppData\Local\Temp\kicad


Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
------          1/1/1601   1:00 AM              1 C:\Users\micro\AppData\Local\Temp\kicad\api.sock

### Proposed fix
Attempt to open the socket 

fn is_missing_ipc_socket(socket_uri: &str) -> bool {
    if let Some(path) = ipc_path_from_uri(socket_uri) {
        #[cfg(windows)]
        {
            // On Windows nng ipc:// uses named pipes, not filesystem sockets.
            // Probe by attempting to open \\.\pipe\<path>.
            // ERROR_PIPE_BUSY (231) means a server is listening but all instances
            // are currently in use — still counts as available.
            let pipe_path = format!(r"\\.\pipe\{}", path.display());
            return match std::fs::OpenOptions::new().read(true).open(&pipe_path) {
                Ok(_) => false,
                Err(e) => e.raw_os_error() != Some(231),
            };
        }

        #[cfg(not(windows))]
        return !path.exists();
    }

    false
}

Tested on Windows 11 version 10.0.26100 