### PR TITLE
Fall back when GetItemsById is AS_UNHANDLED

### DIFF
--- a/src/client/document.rs
+++ b/src/client/document.rs
@@ -206,12 +206,46 @@ impl KiCadClient {
     ///
     /// This is an ergonomic wrapper around [`KiCadClient::get_items_by_id_raw`]
     /// that preserves payloads as editable items for mutate/update workflows.
+    ///
+    /// Falls back to a broader type-code fetch + client-side KIID filter when
+    /// the running KiCad reports `AS_UNHANDLED` for the `GetItemsById`
+    /// command (observed on KiCad 10.0.0 builds where the targeted lookup
+    /// handler is not registered). All other API errors propagate normally.
     pub async fn get_editable_items_by_id(
         &self,
         item_ids: Vec<String>,
     ) -> Result<Vec<EditablePcbItem>, KiCadError> {
-        let items = self.get_items_by_id_raw(item_ids).await?;
-        items.into_iter().map(EditablePcbItem::try_from).collect()
+        if item_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        match self.get_items_by_id_raw(item_ids.clone()).await {
+            Ok(items) => items.into_iter().map(EditablePcbItem::try_from).collect(),
+            Err(err) if super::is_get_items_by_id_unhandled(&err) => {
+                self.get_editable_items_by_id_via_type_codes(&item_ids)
+                    .await
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    /// Fallback for [`KiCadClient::get_editable_items_by_id`] when the
+    /// `GetItemsById` IPC command is unavailable on the running KiCad.
+    ///
+    /// Fetches every known PCB item type via `GetItems` and filters
+    /// client-side by KIID. This path is broader than `GetItemsById`
+    /// (it traverses every item on the board) and is only used when the
+    /// targeted lookup is unsupported.
+    async fn get_editable_items_by_id_via_type_codes(
+        &self,
+        item_ids: &[String],
+    ) -> Result<Vec<EditablePcbItem>, KiCadError> {
+        let type_codes: Vec<i32> = super::PCB_OBJECT_TYPES
+            .iter()
+            .map(|object_type| object_type.code)
+            .collect();
+        let items = self.get_editable_items_by_type_codes(type_codes).await?;
+        Ok(filter_editable_items_by_kiid(items, item_ids))
     }
     /// Fetches and decodes items by KiCad item id.
     pub async fn get_items_by_id(&self, item_ids: Vec<String>) -> Result<Vec<PcbItem>, KiCadError> {
@@ -264,6 +298,22 @@ fn title_block_info_to_proto(title_block: TitleBlockInfo) -> common_types::Title
         comment8: comments.get(7).cloned().unwrap_or_default(),
         comment9: comments.get(8).cloned().unwrap_or_default(),
     }
+}
+
+/// Filters a collection of editable PCB items down to those whose KIID
+/// matches one of the supplied wanted ids.
+///
+/// Items with no KIID (e.g. `Field`, `Unknown`) are dropped. The relative
+/// order of matching items is preserved from the input vector.
+pub(crate) fn filter_editable_items_by_kiid(
+    items: Vec<EditablePcbItem>,
+    wanted_ids: &[String],
+) -> Vec<EditablePcbItem> {
+    let wanted: std::collections::HashSet<&str> = wanted_ids.iter().map(String::as_str).collect();
+    items
+        .into_iter()
+        .filter(|item| item.id().is_some_and(|id| wanted.contains(id)))
+        .collect()
 }
 
 #[cfg(test)]

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -581,6 +581,13 @@ pub(crate) fn is_get_open_documents_unhandled(err: &KiCadError) -> bool {
     )
 }
 
+pub(crate) fn is_get_items_by_id_unhandled(err: &KiCadError) -> bool {
+    matches!(
+        err,
+        KiCadError::ApiStatus { code, .. } if code == "AS_UNHANDLED"
+    )
+}
+
 fn resolve_socket_uri(explicit: Option<&str>) -> String {
     if let Some(socket) = explicit {
         return normalize_socket_uri(socket);

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -1,18 +1,20 @@
 use crate::error::KiCadError;
 
 use super::decode::*;
+use super::document::filter_editable_items_by_kiid;
 use super::format::*;
 use super::items::{
     bucket_items_by_pcb_object_type, deleted_item_ids_from_response, pcb_object_type_for_any,
 };
 use super::mappers::*;
 use super::{
-    envelope, is_get_open_documents_unhandled, normalize_socket_uri, project_path_from_environment,
-    resolve_current_project_path, select_single_board_document, select_single_project_path,
-    CMD_BEGIN_COMMIT, CMD_CREATE_ITEMS, CMD_DELETE_ITEMS, CMD_END_COMMIT, CMD_GET_BOARD_LAYER_NAME,
-    CMD_GET_NETS, CMD_GET_SELECTION, CMD_GET_VERSION, CMD_PING, KIPRJMOD_ENV, PCB_OBJECT_TYPES,
-    RES_BOARD_LAYER_NAME_RESPONSE, RES_CREATE_ITEMS_RESPONSE, RES_DELETE_ITEMS_RESPONSE,
-    RES_GET_NETS, RES_GET_VERSION, RES_PROTOBUF_EMPTY, RES_SELECTION_RESPONSE,
+    envelope, is_get_items_by_id_unhandled, is_get_open_documents_unhandled, normalize_socket_uri,
+    project_path_from_environment, resolve_current_project_path, select_single_board_document,
+    select_single_project_path, CMD_BEGIN_COMMIT, CMD_CREATE_ITEMS, CMD_DELETE_ITEMS,
+    CMD_END_COMMIT, CMD_GET_BOARD_LAYER_NAME, CMD_GET_NETS, CMD_GET_SELECTION, CMD_GET_VERSION,
+    CMD_PING, KIPRJMOD_ENV, PCB_OBJECT_TYPES, RES_BOARD_LAYER_NAME_RESPONSE,
+    RES_CREATE_ITEMS_RESPONSE, RES_DELETE_ITEMS_RESPONSE, RES_GET_NETS, RES_GET_VERSION,
+    RES_PROTOBUF_EMPTY, RES_SELECTION_RESPONSE,
 };
 
 #[cfg(test)]
@@ -22,6 +24,7 @@ mod tests {
         board_text_spec_to_proto, bucket_items_by_pcb_object_type, commit_action_to_proto,
         decode_pcb_item, deleted_item_ids_from_response, drc_severity_to_proto,
         ensure_item_deletion_status_ok, ensure_item_request_ok, ensure_item_status_ok,
+        filter_editable_items_by_kiid, is_get_items_by_id_unhandled,
         is_get_open_documents_unhandled, layer_to_model, map_board_stackup, map_commit_session,
         map_hit_test_result, map_item_bounding_boxes, map_merge_mode_to_proto,
         map_polygon_with_holes, map_run_action_status, model_document_to_proto,
@@ -40,6 +43,7 @@ mod tests {
         CommitAction, DocumentSpecifier, DocumentType, ProjectInfo, TextAttributesSpec,
         TextHorizontalAlignment, TextSpec, TextVerticalAlignment,
     };
+    use crate::pcb_item_type_urls;
     use prost::Message;
     use std::path::PathBuf;
     use std::sync::Mutex;
@@ -182,6 +186,130 @@ mod tests {
             message: "bad request".to_string(),
         };
         assert!(!is_get_open_documents_unhandled(&other));
+    }
+
+    #[test]
+    fn is_get_items_by_id_unhandled_matches_expected_shape() {
+        let unhandled = KiCadError::ApiStatus {
+            code: "AS_UNHANDLED".to_string(),
+            message: "no handler available for request of type kiapi.common.commands.GetItemsById"
+                .to_string(),
+        };
+        assert!(is_get_items_by_id_unhandled(&unhandled));
+
+        let other = KiCadError::ApiStatus {
+            code: "AS_BAD_REQUEST".to_string(),
+            message: "bad request".to_string(),
+        };
+        assert!(!is_get_items_by_id_unhandled(&other));
+
+        // Non-status errors must not match either, so the fallback path is
+        // never taken for transport / decode / IO failures.
+        assert!(!is_get_items_by_id_unhandled(&KiCadError::BoardNotOpen));
+        assert!(!is_get_items_by_id_unhandled(
+            &KiCadError::TransportReceive {
+                reason: "connection closed".to_string()
+            }
+        ));
+    }
+
+    #[test]
+    fn filter_editable_items_by_kiid_keeps_only_matching_items() {
+        use crate::model::editable::EditablePcbItem;
+        use crate::proto::kiapi::{board::types as board_types, common::types as common_types};
+        use prost::Message;
+        use prost_types::Any;
+
+        fn pack<T: Message>(message: &T, type_name: &str) -> Any {
+            super::envelope::pack_any(message, type_name)
+        }
+
+        fn track_with_id(id: &str) -> EditablePcbItem {
+            EditablePcbItem::from_any(pack(
+                &board_types::Track {
+                    id: Some(common_types::Kiid {
+                        value: id.to_string(),
+                    }),
+                    ..Default::default()
+                },
+                pcb_item_type_urls::TRACK,
+            ))
+            .expect("track should decode")
+        }
+
+        fn track_without_id() -> EditablePcbItem {
+            EditablePcbItem::from_any(pack(
+                &board_types::Track::default(),
+                pcb_item_type_urls::TRACK,
+            ))
+            .expect("track should decode")
+        }
+
+        let items = vec![
+            track_with_id("kiid-1"),
+            track_with_id("kiid-2"),
+            track_with_id("kiid-3"),
+            track_without_id(),
+        ];
+
+        let wanted = vec!["kiid-1".to_string(), "kiid-3".to_string()];
+        let filtered = filter_editable_items_by_kiid(items, &wanted);
+
+        let ids: Vec<&str> = filtered.iter().filter_map(|item| item.id()).collect();
+        assert_eq!(ids, vec!["kiid-1", "kiid-3"]);
+    }
+
+    #[test]
+    fn filter_editable_items_by_kiid_returns_empty_when_no_matches() {
+        use crate::model::editable::EditablePcbItem;
+        use crate::proto::kiapi::{board::types as board_types, common::types as common_types};
+        use prost::Message;
+        use prost_types::Any;
+
+        fn pack<T: Message>(message: &T, type_name: &str) -> Any {
+            super::envelope::pack_any(message, type_name)
+        }
+
+        let items = vec![EditablePcbItem::from_any(pack(
+            &board_types::Track {
+                id: Some(common_types::Kiid {
+                    value: "present".to_string(),
+                }),
+                ..Default::default()
+            },
+            pcb_item_type_urls::TRACK,
+        ))
+        .expect("track should decode")];
+
+        let wanted = vec!["missing".to_string()];
+        let filtered = filter_editable_items_by_kiid(items, &wanted);
+        assert!(filtered.is_empty());
+    }
+
+    #[test]
+    fn filter_editable_items_by_kiid_returns_empty_for_empty_wanted() {
+        use crate::model::editable::EditablePcbItem;
+        use crate::proto::kiapi::{board::types as board_types, common::types as common_types};
+        use prost::Message;
+        use prost_types::Any;
+
+        fn pack<T: Message>(message: &T, type_name: &str) -> Any {
+            super::envelope::pack_any(message, type_name)
+        }
+
+        let items = vec![EditablePcbItem::from_any(pack(
+            &board_types::Track {
+                id: Some(common_types::Kiid {
+                    value: "anything".to_string(),
+                }),
+                ..Default::default()
+            },
+            pcb_item_type_urls::TRACK,
+        ))
+        .expect("track should decode")];
+
+        let filtered = filter_editable_items_by_kiid(items, &[]);
+        assert!(filtered.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Fixes #31.

On KiCad 10.0.0 where GetItemsById isn't registered, get_editable_items_by_id now falls back to fetching every known PCB item type via GetItems and filtering client-side by KIID. Other API errors still propagate. Unit tests cover the helper and the filter; live-tested against KiCad 10.0.4 (5/5 KIIDs returned correctly on a TCU board).